### PR TITLE
Potential fix for code scanning alert no. 150: Resolving XML external entity in user-controlled data

### DIFF
--- a/saml/saml-core/src/main/java/org/keycloak/saml/common/util/StaxParserUtil.java
+++ b/saml/saml-core/src/main/java/org/keycloak/saml/common/util/StaxParserUtil.java
@@ -250,6 +250,7 @@ public class StaxParserUtil {
             xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
             xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
             xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
+            xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
 
             xmlEventReader = xmlInputFactory.createXMLEventReader(is);
         } catch (Exception ex) {


### PR DESCRIPTION
Potential fix for [https://github.com/eroad/keycloak/security/code-scanning/150](https://github.com/eroad/keycloak/security/code-scanning/150)

To fully mitigate XXE vulnerabilities when parsing untrusted XML with StAX, you must disable both external entity resolution and DTD support. The code already sets `XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES` to `false`, but it does not set `XMLInputFactory.SUPPORT_DTD` to `false`. The best fix is to add the following line after the other property settings in the `getXMLEventReader` method in `StaxParserUtil.java`:

```java
xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
```

This ensures that DTDs are not processed at all, closing the XXE vector. No changes to imports or method signatures are required, as `XMLInputFactory.SUPPORT_DTD` is already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
